### PR TITLE
Revert "bacon: we have a device with 3GB RAM"

### DIFF
--- a/bacon.mk
+++ b/bacon.mk
@@ -35,7 +35,7 @@ PRODUCT_PACKAGES += \
     camera.msm8974
 
 # Dalvik
-$(call inherit-product-if-exists, frameworks/native/build/phone-xxhdpi-3072-dalvik-heap.mk)
+$(call inherit-product-if-exists, frameworks/native/build/phone-xxhdpi-2048-dalvik-heap.mk)
 
 # Display
 PRODUCT_AAPT_CONFIG := normal


### PR DESCRIPTION
Causes stability issues (like crashes), performance-heavy games are affected mostly.

This reverts commit 4730417d9ab1a98fa46b3691961d0ff5b0c8ea0a.

Change-Id: I73c4c6ad131f1ed7a6a138d1f1af3a9bf12fdc6f